### PR TITLE
Improve deserializer coverage

### DIFF
--- a/datason/datetime_utils.py
+++ b/datason/datetime_utils.py
@@ -130,11 +130,10 @@ def ensure_dates(df: Any, strip_timezone: bool = True) -> Any:
         KeyError: If date column is missing in DataFrame
         ValueError: If date format is invalid
     """
-    if pd is None:
-        raise ImportError("pandas is required for ensure_dates function")
-
-    # Handle dictionaries
+    # Handle dictionaries first so type validation happens before pandas check
     if isinstance(df, dict):
+        if pd is None:
+            raise ImportError("pandas is required for ensure_dates function")
         result = df.copy()
         # Convert date fields in the dictionary
         date_fields = [
@@ -159,6 +158,11 @@ def ensure_dates(df: Any, strip_timezone: bool = True) -> Any:
         return result
 
     # Handle DataFrames - original implementation
+    if pd is None:
+        if isinstance(df, dict):
+            raise ImportError("pandas is required for ensure_dates function")
+        raise TypeError(f"Input must be a pandas DataFrame or dict, got {type(df)}")
+
     if not isinstance(df, pd.DataFrame):
         raise TypeError(f"Input must be a pandas DataFrame or dict, got {type(df)}")
     if "date" not in df.columns:

--- a/datason/ml_serializers.py
+++ b/datason/ml_serializers.py
@@ -35,6 +35,8 @@ def _lazy_import_torch():
         patched_value = current_module.__dict__["torch"]
         if patched_value is None:
             return None
+        _LAZY_IMPORTS["torch"] = patched_value
+        return patched_value
 
     if _LAZY_IMPORTS["torch"] is None:
         try:
@@ -56,6 +58,8 @@ def _lazy_import_tensorflow():
         patched_value = current_module.__dict__["tf"]
         if patched_value is None:
             return None
+        _LAZY_IMPORTS["tensorflow"] = patched_value
+        return patched_value
 
     if _LAZY_IMPORTS["tensorflow"] is None:
         try:
@@ -77,6 +81,12 @@ def _lazy_import_jax():
         patched_value = current_module.__dict__["jax"]
         if patched_value is None:
             return None, None
+        _LAZY_IMPORTS["jax"] = patched_value
+        _LAZY_IMPORTS["jnp"] = getattr(patched_value, "numpy", None)
+        return (
+            _LAZY_IMPORTS["jax"],
+            _LAZY_IMPORTS["jnp"],
+        )
 
     if _LAZY_IMPORTS["jax"] is None or _LAZY_IMPORTS["jnp"] is None:
         try:
@@ -101,10 +111,16 @@ def _lazy_import_sklearn():
 
     current_module = sys.modules.get(__name__)
     if current_module and hasattr(current_module, "__dict__"):
-        if "sklearn" in current_module.__dict__ and current_module.__dict__["sklearn"] is None:
-            return None, None
-        if "BaseEstimator" in current_module.__dict__ and current_module.__dict__["BaseEstimator"] is None:
-            return None, None
+        if "sklearn" in current_module.__dict__:
+            patched = current_module.__dict__["sklearn"]
+            if patched is None:
+                return None, None
+            _LAZY_IMPORTS["sklearn"] = patched
+        if "BaseEstimator" in current_module.__dict__:
+            patched_base = current_module.__dict__["BaseEstimator"]
+            if patched_base is None:
+                return None, None
+            _LAZY_IMPORTS["BaseEstimator"] = patched_base
 
     if _LAZY_IMPORTS["sklearn"] is None or _LAZY_IMPORTS["BaseEstimator"] is None:
         try:
@@ -132,6 +148,8 @@ def _lazy_import_scipy():
         patched_value = current_module.__dict__["scipy"]
         if patched_value is None:
             return None
+        _LAZY_IMPORTS["scipy"] = patched_value
+        return patched_value
 
     if _LAZY_IMPORTS["scipy"] is None:
         try:
@@ -153,6 +171,8 @@ def _lazy_import_pil():
         patched_value = current_module.__dict__["Image"]
         if patched_value is None:
             return None
+        _LAZY_IMPORTS["PIL_Image"] = patched_value
+        return patched_value
 
     if _LAZY_IMPORTS["PIL_Image"] is None:
         try:
@@ -174,6 +194,8 @@ def _lazy_import_transformers():
         patched_value = current_module.__dict__["transformers"]
         if patched_value is None:
             return None
+        _LAZY_IMPORTS["transformers"] = patched_value
+        return patched_value
 
     if _LAZY_IMPORTS["transformers"] is None:
         try:
@@ -425,7 +447,11 @@ def detect_and_serialize_ml_object(obj: Any) -> Optional[Dict[str, Any]]:
 
     # Scikit-learn models
     sklearn, BaseEstimator = _lazy_import_sklearn()
-    if sklearn is not None and BaseEstimator is not None and isinstance(obj, BaseEstimator):
+    if (
+        sklearn is not None
+        and isinstance(BaseEstimator, type)
+        and isinstance(obj, BaseEstimator)
+    ):
         return serialize_sklearn_model(obj)
 
     # Scipy sparse matrices

--- a/tests/coverage/test_deserializers_additional.py
+++ b/tests/coverage/test_deserializers_additional.py
@@ -1,0 +1,197 @@
+import sys
+import types
+from datetime import datetime
+import uuid
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from datason.deserializers import (
+    _convert_string_keys_to_int_if_possible,
+    _try_numpy_array_detection,
+    _looks_like_numpy_array,
+    _deserialize_with_type_metadata,
+)
+
+
+class DummyNumpy(types.ModuleType):
+    class ndarray(list):
+        def __init__(self, data):
+            super().__init__(data)
+            self.shape = (len(data),)
+        def astype(self, dtype):
+            self.dtype = dtype
+            return self
+        def reshape(self, shape):
+            self.shape = tuple(shape)
+            return self
+
+    def array(self, data):
+        return DummyNumpy.ndarray(data)
+
+
+def test_convert_string_keys_basic():
+    data = {"1": "a", "-2": "b", "3.5": "c", "x": 1}
+    result = _convert_string_keys_to_int_if_possible(data)
+    assert result == {1: "a", -2: "b", "3.5": "c", "x": 1}
+
+
+def test_convert_string_keys_non_string():
+    data = {1: "a", "two": 2}
+    result = _convert_string_keys_to_int_if_possible(data)
+    assert result == {1: "a", "two": 2}
+
+
+def test_try_numpy_array_detection_without_numpy():
+    assert _try_numpy_array_detection([1, 2, 3]) is None
+
+
+def test_try_numpy_array_detection_with_numpy(monkeypatch):
+    dummy = DummyNumpy("numpy")
+    monkeypatch.setitem(sys.modules, "numpy", dummy)
+    result = _try_numpy_array_detection([1, 2, 3, 4, 5, 6, 7, 8])
+    assert isinstance(result, DummyNumpy.ndarray)
+    assert list(result) == [1, 2, 3, 4, 5, 6, 7, 8]
+
+
+def test_looks_like_numpy_array(monkeypatch):
+    dummy = DummyNumpy("numpy")
+    monkeypatch.setitem(sys.modules, "numpy", dummy)
+    arr1 = DummyNumpy.ndarray([1, 2])
+    arr2 = DummyNumpy.ndarray([3, 4])
+    assert _looks_like_numpy_array([arr1, arr2])
+    assert _looks_like_numpy_array([arr1, [3, "a"]])
+
+
+class DummyPandas(types.ModuleType):
+    class CategoricalDtype:
+        def __init__(self, categories=None, ordered=False):
+            self.categories = categories
+            self.ordered = ordered
+
+    class Series(list):
+        def __init__(self, data=None, index=None, name=None):
+            if isinstance(data, dict):
+                index = list(data.keys())
+                data = list(data.values())
+            super().__init__(data if data is not None else [])
+            self.index = index
+            self.name = name
+
+        def astype(self, dtype):
+            self.dtype = dtype
+            return self
+
+    class DataFrame:
+        def __init__(self, data=None, index=None, columns=None, orient=None):
+            self.data = data
+            self.index = index
+            self.columns = columns
+            self.orient = orient
+
+        @classmethod
+        def from_dict(cls, data, orient="columns"):
+            return cls(data=data, orient=orient)
+
+    def __init__(self, name="pandas"):
+        super().__init__(name)
+        self.Series = DummyPandas.Series
+        self.DataFrame = DummyPandas.DataFrame
+        self.CategoricalDtype = DummyPandas.CategoricalDtype
+
+
+def test_deserialize_with_type_metadata_basic(monkeypatch):
+    dummy_pd = DummyPandas()
+    monkeypatch.setattr(sys.modules["datason.deserializers"], "pd", dummy_pd, raising=False)
+    dummy_np = DummyNumpy("numpy")
+    monkeypatch.setitem(sys.modules, "numpy", dummy_np)
+
+    dt_str = "2023-01-02T03:04:05"
+    uuid_str = "12345678-1234-5678-1234-567812345678"
+    assert _deserialize_with_type_metadata({"__datason_type__": "datetime", "__datason_value__": dt_str}) == datetime.fromisoformat(dt_str)
+    assert _deserialize_with_type_metadata({"__datason_type__": "uuid.UUID", "__datason_value__": uuid_str}) == uuid.UUID(uuid_str)
+    assert _deserialize_with_type_metadata({"__datason_type__": "complex", "__datason_value__": {"real": 1, "imag": 2}}) == 1 + 2j
+    assert _deserialize_with_type_metadata({"__datason_type__": "decimal.Decimal", "__datason_value__": "3.14"}) == Decimal("3.14")
+    assert _deserialize_with_type_metadata({"__datason_type__": "pathlib.Path", "__datason_value__": "/tmp"}) == Path("/tmp")
+    assert _deserialize_with_type_metadata({"__datason_type__": "set", "__datason_value__": [1, 2]}) == {1, 2}
+    assert _deserialize_with_type_metadata({"__datason_type__": "tuple", "__datason_value__": [1, 2]}) == (1, 2)
+
+    df_meta = {"__datason_type__": "pandas.DataFrame", "__datason_value__": {"index": [0, 1], "columns": ["a"], "data": [[1], [2]]}}
+    df_result = _deserialize_with_type_metadata(df_meta)
+    assert isinstance(df_result, DummyPandas.DataFrame)
+    assert df_result.data == [[1], [2]]
+    assert df_result.index == [0, 1]
+    assert df_result.columns == ["a"]
+
+    series_meta = {"__datason_type__": "pandas.Series", "__datason_value__": [1, 2, 3]}
+    series_result = _deserialize_with_type_metadata(series_meta)
+    assert isinstance(series_result, DummyPandas.Series)
+    assert list(series_result) == [1, 2, 3]
+
+
+def test_deserialize_with_numpy_and_torch(monkeypatch):
+    dummy_pd = DummyPandas()
+    dummy_np = DummyNumpy("numpy")
+    dummy_np.int32 = lambda x: f"int32({x})"
+    dummy_np.int64 = lambda x: f"int64({x})"
+    dummy_np.float32 = lambda x: f"float32({x})"
+    dummy_np.float64 = lambda x: f"float64({x})"
+    dummy_np.bool_ = bool
+    dummy_np.complex128 = complex
+
+    class DummyTensor(list):
+        def __init__(self, data, device="cpu", requires_grad=False):
+            super().__init__(data)
+            self.device = device
+            self.requires_grad = requires_grad
+        def to(self, dtype):
+            self.dtype = dtype
+            return self
+        def numel(self):
+            return len(self)
+        def reshape(self, shape):
+            return self
+
+    class DummyTorch(types.ModuleType):
+        float32 = "float32"
+        def __init__(self):
+            super().__init__("torch")
+        def tensor(self, data, device="cpu", requires_grad=False):
+            return DummyTensor(data, device, requires_grad)
+
+    dummy_torch = DummyTorch()
+
+    sk_mod = types.ModuleType("sklearn.linear_model")
+    class DummyModel:
+        def __init__(self, **params):
+            self.params = params
+    sk_mod.LinearRegression = DummyModel
+
+    monkeypatch.setattr(sys.modules["datason.deserializers"], "pd", dummy_pd, raising=False)
+    monkeypatch.setattr(sys.modules["datason.deserializers"], "np", dummy_np, raising=False)
+    monkeypatch.setitem(sys.modules, "numpy", dummy_np)
+    monkeypatch.setitem(sys.modules, "torch", dummy_torch)
+    monkeypatch.setitem(sys.modules, "sklearn.linear_model", sk_mod)
+
+    ndarray_meta = {"__datason_type__": "numpy.ndarray", "__datason_value__": {"data": [1, 2, 3, 4], "dtype": "float32", "shape": [2, 2]}}
+    ndarray_result = _deserialize_with_type_metadata(ndarray_meta)
+    assert isinstance(ndarray_result, DummyNumpy.ndarray)
+    assert list(ndarray_result) == [1, 2, 3, 4]
+
+    scalar_meta = {"__datason_type__": "numpy.int32", "__datason_value__": 5}
+    assert _deserialize_with_type_metadata(scalar_meta) == "int32(5)"
+
+    tensor_meta = {
+        "__datason_type__": "torch.Tensor",
+        "__datason_value__": {"_data": [1, 2], "_dtype": "float32", "_device": "cpu", "_requires_grad": True, "_shape": [2]},
+    }
+    tensor = _deserialize_with_type_metadata(tensor_meta)
+    assert isinstance(tensor, DummyTensor)
+    assert tensor.device == "cpu"
+    assert tensor.requires_grad is True
+
+    skl_meta = {"__datason_type__": "sklearn.linear_model.LinearRegression", "__datason_value__": {"_class": "sklearn.linear_model.LinearRegression", "_params": {"a": 1}}}
+    model = _deserialize_with_type_metadata(skl_meta)
+    assert isinstance(model, DummyModel)
+    assert model.params == {"a": 1}

--- a/tests/coverage/test_lazy_imports_and_hotpath.py
+++ b/tests/coverage/test_lazy_imports_and_hotpath.py
@@ -1,0 +1,87 @@
+import builtins
+import types
+import sys
+import pytest
+
+from datason.ml_serializers import (
+    _LAZY_IMPORTS,
+    _lazy_import_torch,
+    _lazy_import_tensorflow,
+    _lazy_import_sklearn,
+    __getattr__ as ml_getattr,
+)
+from datason.deserializers import deserialize_fast, DeserializationSecurityError
+from datason.config import SerializationConfig
+
+
+class DummyTorch(types.ModuleType):
+    pass
+
+
+class DummyTensorFlow(types.ModuleType):
+    pass
+
+
+class DummySklearn(types.ModuleType):
+    class BaseEstimator:
+        pass
+
+
+def test_lazy_import_torch_respects_patch(monkeypatch):
+    dummy = DummyTorch("torch")
+    _LAZY_IMPORTS["torch"] = None
+    module = sys.modules['datason.ml_serializers']
+    monkeypatch.setattr(module, 'torch', dummy, raising=False)
+    assert _lazy_import_torch() is dummy
+    # cached value should be reused even if attribute changes
+    del module.__dict__['torch']
+    assert _lazy_import_torch() is dummy
+    # __getattr__ should also return the cached module
+    assert ml_getattr('torch') is dummy
+
+
+def test_lazy_import_tensorflow_missing(monkeypatch):
+    _LAZY_IMPORTS["tensorflow"] = None
+    if 'tensorflow' in sys.modules:
+        monkeypatch.delitem(sys.modules, 'tensorflow', raising=False)
+    def fake_import(name, *args, **kwargs):
+        if name == 'tensorflow' or name.startswith('tensorflow.'):
+            raise ImportError('no tf')
+        return original_import(name, *args, **kwargs)
+    original_import = builtins.__import__
+    monkeypatch.setattr(builtins, '__import__', fake_import)
+    module = sys.modules['datason.ml_serializers']
+    module.__dict__.pop('tf', None)
+    assert _lazy_import_tensorflow() is None
+
+
+def test_lazy_import_sklearn_respects_patch(monkeypatch):
+    dummy_sk = DummySklearn('sklearn')
+    dummy_base = DummySklearn.BaseEstimator
+    _LAZY_IMPORTS['sklearn'] = None
+    _LAZY_IMPORTS['BaseEstimator'] = None
+    module = sys.modules['datason.ml_serializers']
+    monkeypatch.setattr(module, 'sklearn', dummy_sk, raising=False)
+    monkeypatch.setattr(module, 'BaseEstimator', dummy_base, raising=False)
+    sk, be = _lazy_import_sklearn()
+    assert sk is dummy_sk
+    assert be is dummy_base
+    # Cache should persist
+    del module.__dict__['sklearn']
+    del module.__dict__['BaseEstimator']
+    sk_cached, be_cached = _lazy_import_sklearn()
+    assert sk_cached is dummy_sk
+    assert be_cached is dummy_base
+
+
+def test_deserialize_fast_security_exceptions():
+    config = SerializationConfig(max_size=3, max_depth=2)
+    big_list = [1, 2, 3, 4]
+    big_dict = {i: i for i in range(5)}
+    with pytest.raises(DeserializationSecurityError, match='List size'):
+        deserialize_fast(big_list, config)
+    with pytest.raises(DeserializationSecurityError, match='Dictionary size'):
+        deserialize_fast(big_dict, config)
+    deep = {'a': {'b': {'c': {'d': 1}}}}
+    with pytest.raises(DeserializationSecurityError, match='depth'):
+        deserialize_fast(deep, config)


### PR DESCRIPTION
## Summary
- patch lazy import helpers to honor test monkeypatching
- adjust `ensure_dates` validation order
- add extensive deserializer coverage tests
- add tests for ML lazy imports and hotpath exceptions

## Testing
- `pytest tests/coverage/test_lazy_imports_and_hotpath.py -q`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6841f807e2b88325a4053976f7c077b6