### PR TITLE
Update Python compatibility docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ datason officially supports **Python 3.8+** and is actively tested on:
 - ✅ **Python 3.9** - Full compatibility  
 - ✅ **Python 3.10** - Full compatibility
 - ✅ **Python 3.11** - Full compatibility (primary development version)
-- ✅ **Python 3.12** - Latest stable version
+- ✅ **Python 3.12** - Full compatibility
+- ✅ **Python 3.13** - Latest stable version
 
 ### Compatibility Testing
 
@@ -42,7 +43,8 @@ We maintain compatibility through:
   - **Python 3.9**: Data science focus (pandas integration)
   - **Python 3.10**: ML focus (scikit-learn, scipy)
   - **Python 3.11**: Full test suite (primary development version)
-  - **Python 3.12**: Full test suite (latest stable)
+  - **Python 3.12**: Full test suite
+  - **Python 3.13**: Full test suite (latest stable)
 - **Core functionality tests** ensuring basic serialization works on Python 3.8+
 - **Dependency compatibility checks** for optional ML/data science libraries
 - **Runtime version validation** with helpful error messages

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ datason officially supports **Python 3.8+** and is actively tested on:
 - ✅ **Python 3.10** - Full compatibility
 - ✅ **Python 3.11** - Full compatibility (primary development version)
 - ✅ **Python 3.12** - Full compatibility
-- ✅ **Python 3.13** - Latest stable version
+- ✅ **Python 3.13** - Latest stable version (core features only; many ML libraries still releasing wheels)
 
 ### Compatibility Testing
 
@@ -44,12 +44,14 @@ We maintain compatibility through:
   - **Python 3.10**: ML focus (scikit-learn, scipy)
   - **Python 3.11**: Full test suite (primary development version)
   - **Python 3.12**: Full test suite
-  - **Python 3.13**: Full test suite (latest stable)
+  - **Python 3.13**: Core serialization tests only (latest stable)
 - **Core functionality tests** ensuring basic serialization works on Python 3.8+
 - **Dependency compatibility checks** for optional ML/data science libraries
 - **Runtime version validation** with helpful error messages
 
 > **Note**: While core functionality works on Python 3.8, some optional dependencies (like latest ML frameworks) may require newer Python versions. The package will still work - you'll just have fewer optional features available.
+>
+> **Python 3.13 Caution**: Many machine learning libraries have not yet released official 3.13 builds. Datason runs on Python 3.13, but only with core serialization features until those libraries catch up.
 
 ### Python 3.8 Limitations
 

--- a/docs/CI_PIPELINE_GUIDE.md
+++ b/docs/CI_PIPELINE_GUIDE.md
@@ -403,7 +403,7 @@ repos:
 ```yaml
 strategy:
   matrix:
-    python-version: [3.8, 3.9, 3.10, 3.11, 3.12]
+    python-version: [3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
 ```
 
 ## 🎯 **Best Practices**

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -97,7 +97,7 @@ def test_large_dataset_performance():
 ## 🛠️ Development Setup
 
 ### Prerequisites
-- Python 3.8+ (we support 3.8-3.12)
+- Python 3.8+ (we support 3.8-3.13)
 - Git
 - Virtual environment (recommended)
 

--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -97,7 +97,7 @@ def test_large_dataset_performance():
 ## 🛠️ Development Setup
 
 ### Prerequisites
-- Python 3.8+ (we support 3.8-3.12)
+- Python 3.8+ (we support 3.8-3.13)
 - Git
 - Virtual environment (recommended)
 


### PR DESCRIPTION
## Summary
- list Python 3.13 as the latest stable version in README
- mention testing with Python 3.13
- update contributing docs with new version range
- show Python 3.13 in the CI example matrix

## Testing
- `pytest -q` *(fails: tests/coverage/test_ml_with_real_libraries.py)*

------
https://chatgpt.com/codex/tasks/task_e_6842da8d8c7883258919a385ffebaadb