### PR TITLE
Add Pydantic and Marshmallow integration docs

### DIFF
--- a/datason/__init__.py
+++ b/datason/__init__.py
@@ -127,6 +127,10 @@ try:
 except ImportError:
     _pickle_bridge_available = False
 
+# Validation helpers (always available, dependencies imported lazily)
+from . import validation  # noqa: F401
+from .validation import serialize_marshmallow, serialize_pydantic  # noqa: F401
+
 # Always import datetime_utils module for tests
 from . import datetime_utils  # noqa: F401
 
@@ -310,6 +314,9 @@ if _pickle_bridge_available:
             "get_ml_safe_classes",
         ]
     )
+
+# Always expose validation helpers
+__all__.extend(["serialize_pydantic", "serialize_marshmallow"])
 
 
 # Convenience functions for quick access

--- a/datason/core.py
+++ b/datason/core.py
@@ -897,6 +897,26 @@ def _serialize_full_path(
             # Fallback: Return enum value (legacy behavior when no config)
             return obj.value
 
+    # Handle Pydantic BaseModel objects
+    try:
+        from .validation import BaseModel  # type: ignore
+    except Exception:
+        BaseModel = None
+    if BaseModel is not None and isinstance(obj, BaseModel):
+        from .validation import serialize_pydantic
+
+        return serialize_pydantic(obj)
+
+    # Handle Marshmallow Schema objects
+    try:
+        from .validation import Schema  # type: ignore
+    except Exception:
+        Schema = None
+    if Schema is not None and isinstance(obj, Schema):
+        from .validation import serialize_marshmallow
+
+        return serialize_marshmallow(obj)
+
     # Handle objects with __dict__ (custom classes)
     if hasattr(obj, "__dict__"):
         # SECURITY: Early detection of problematic objects that can cause deep recursion

--- a/datason/validation.py
+++ b/datason/validation.py
@@ -1,0 +1,77 @@
+# Optional integration helpers for Pydantic and Marshmallow
+from typing import Any, Dict
+
+from .core import serialize
+
+_LAZY_IMPORTS = {
+    "BaseModel": None,
+    "Schema": None,
+}
+
+
+def _lazy_import_pydantic_base_model():
+    """Lazily import pydantic.BaseModel."""
+    if _LAZY_IMPORTS["BaseModel"] is None:
+        try:
+            from pydantic import BaseModel
+
+            _LAZY_IMPORTS["BaseModel"] = BaseModel
+        except Exception:
+            _LAZY_IMPORTS["BaseModel"] = False
+    return _LAZY_IMPORTS["BaseModel"] if _LAZY_IMPORTS["BaseModel"] is not False else None
+
+
+def _lazy_import_marshmallow_schema():
+    """Lazily import marshmallow.Schema."""
+    if _LAZY_IMPORTS["Schema"] is None:
+        try:
+            from marshmallow import Schema
+
+            _LAZY_IMPORTS["Schema"] = Schema
+        except Exception:
+            _LAZY_IMPORTS["Schema"] = False
+    return _LAZY_IMPORTS["Schema"] if _LAZY_IMPORTS["Schema"] is not False else None
+
+
+def serialize_pydantic(obj: Any) -> Any:
+    """Serialize a Pydantic model using datason."""
+    BaseModel = _lazy_import_pydantic_base_model()
+    if BaseModel is None:
+        raise ImportError("Pydantic is required for serialize_pydantic")
+    if isinstance(obj, BaseModel):
+        try:
+            data = obj.model_dump()  # Pydantic v2
+        except AttributeError:
+            try:
+                data = obj.dict()  # Pydantic v1
+            except Exception:
+                data = obj.__dict__
+        return serialize(data)
+    return serialize(obj)
+
+
+def serialize_marshmallow(obj: Any) -> Any:
+    """Serialize a Marshmallow schema object or validated data."""
+    Schema = _lazy_import_marshmallow_schema()
+    if Schema is None:
+        raise ImportError("Marshmallow is required for serialize_marshmallow")
+    if isinstance(obj, Schema):
+        try:
+            fields: Dict[str, Any] = {
+                name: field.__class__.__name__ for name, field in obj.fields.items()
+            }
+            return serialize(fields)
+        except Exception:
+            return serialize(obj.__dict__)
+    return serialize(obj)
+
+
+# Attribute access for tests
+
+def __getattr__(name: str) -> Any:
+    if name == "BaseModel":
+        return _lazy_import_pydantic_base_model()
+    if name == "Schema":
+        return _lazy_import_marshmallow_schema()
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+

--- a/docs/features/pydantic-marshmallow-integration.md
+++ b/docs/features/pydantic-marshmallow-integration.md
@@ -1,0 +1,64 @@
+# Pydantic & Marshmallow Integration
+
+This document outlines how to integrate Datason with popular schema validation libraries **Pydantic** and **Marshmallow**. The goal is to keep validation and schema generation in their respective libraries while leveraging Datason for serialization and deserialization.
+
+## Background
+
+Many users validate input data with Pydantic or Marshmallow before working with ML/AI workflows. They want an easy way to serialize these validated objects using Datason without losing type fidelity.
+
+## Key Points
+
+- **Validation** remains the responsibility of Pydantic or Marshmallow.
+- **Serialization** is handled by Datason.
+- Integration helpers are optional and incur no new default dependencies.
+
+## Serializing Pydantic Models
+
+```python
+from pydantic import BaseModel
+import datason
+
+class MyModel(BaseModel):
+    a: int
+    b: str
+
+model = MyModel(a=1, b="foo")
+json_data = datason.serialize(model)  # Or datason.serialize_pydantic(model)
+```
+
+Datason automatically extracts fields from `BaseModel` instances, including nested models. Type information is preserved so the data can be deserialized back to Python primitives or dictionaries.
+
+## Serializing Marshmallow Objects
+
+```python
+from marshmallow import Schema, fields
+import datason
+
+class UserSchema(Schema):
+    id = fields.Int()
+    name = fields.Str()
+
+schema = UserSchema()
+user = schema.load({"id": 1, "name": "Alice"})
+json_data = datason.serialize(user)  # Or datason.serialize_marshmallow(user)
+```
+
+The helpers work with the results of `.load()` or `.dump()`, enabling seamless round-tripping through Datason without rewriting validation logic.
+
+## Optional Dependencies
+
+Datason’s core package does not require Pydantic or Marshmallow. If you use these helpers without installing the corresponding library, Datason raises a helpful `ImportError` explaining the missing dependency.
+
+## Documentation & Examples
+
+- [Using Datason with Pydantic](pydantic-marshmallow-integration.md)
+- [Using Datason with Marshmallow](pydantic-marshmallow-integration.md)
+
+Include real-world examples in the docs (e.g., FastAPI with Pydantic, Flask with Marshmallow) to demonstrate how Datason plugs into existing validation flows.
+
+## Limitations
+
+- Datason does not perform schema validation.
+- Custom Pydantic or Marshmallow fields may require user-defined type handlers for perfect fidelity.
+
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,6 +78,7 @@ assert type(restored['array']) == np.ndarray
     **Integration Guides**
 
     - [🤖 AI Integration Guide](ai-guide/overview.md) - How to integrate datason in AI systems
+    - [📦 Pydantic & Marshmallow Integration](features/pydantic-marshmallow-integration.md) - Serialize validated objects
     - [📝 API Reference](api/index.md) - Complete API documentation with examples
     - [🔧 Configuration Presets](features/configuration/index.md) - Pre-built configs for common AI use cases
 

--- a/tests/features/test_validation_integration.py
+++ b/tests/features/test_validation_integration.py
@@ -1,0 +1,48 @@
+import datason
+import pytest
+
+
+@pytest.mark.features
+def test_serialize_pydantic_model() -> None:
+    BaseModel = pytest.importorskip("pydantic").BaseModel
+
+    class MyModel(BaseModel):
+        a: int
+        b: str
+
+    model = MyModel(a=1, b="foo")
+    result = datason.serialize(model)
+    assert result == {"a": 1, "b": "foo"}
+
+    result2 = datason.serialize_pydantic(model)
+    assert result2 == result
+
+
+@pytest.mark.features
+def test_serialize_marshmallow_object() -> None:
+    marshmallow = pytest.importorskip("marshmallow")
+
+    class UserSchema(marshmallow.Schema):
+        id = marshmallow.fields.Int()
+        name = marshmallow.fields.Str()
+
+    schema = UserSchema()
+    user = schema.load({"id": 1, "name": "Alice"})
+
+    result = datason.serialize(user)
+    assert result == {"id": 1, "name": "Alice"}
+
+    result2 = datason.serialize_marshmallow(user)
+    assert result2 == result
+
+
+@pytest.mark.features
+def test_pydantic_helper_import_error(monkeypatch) -> None:
+    # Simulate missing pydantic
+    import importlib
+
+    monkeypatch.setitem(datason.validation._LAZY_IMPORTS, "BaseModel", False)
+
+    with pytest.raises(ImportError):
+        datason.validation.serialize_pydantic(object())
+

--- a/tests/integration/test_validation_full_round_trip.py
+++ b/tests/integration/test_validation_full_round_trip.py
@@ -1,0 +1,37 @@
+import datason
+import pytest
+
+
+def test_pydantic_round_trip() -> None:
+    BaseModel = pytest.importorskip("pydantic").BaseModel
+
+    class Model(BaseModel):
+        a: int
+        b: str
+
+    raw = {"a": 2, "b": "bar"}
+    model = Model(**raw)
+
+    serialized = datason.serialize(model)
+    deserialized = datason.deserialize(serialized)
+    new_model = Model(**deserialized)
+
+    assert new_model == model
+
+
+def test_marshmallow_round_trip() -> None:
+    marshmallow = pytest.importorskip("marshmallow")
+
+    class UserSchema(marshmallow.Schema):
+        id = marshmallow.fields.Int()
+        name = marshmallow.fields.Str()
+
+    schema = UserSchema()
+    raw = {"id": 3, "name": "Bob"}
+    user = schema.load(raw)
+
+    serialized = datason.serialize(user)
+    deserialized = datason.deserialize(serialized)
+    user2 = schema.load(deserialized)
+
+    assert user2 == user


### PR DESCRIPTION
## Summary
- document how to integrate Datason with Pydantic and Marshmallow
- link the new guide from the docs homepage
- implement optional helpers `serialize_pydantic` and `serialize_marshmallow`
- auto-detect pydantic models and marshmallow schemas in core serialization
- test the integration helpers

## Testing
- `pytest -c /dev/null tests/features/test_validation_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f9de5a0483259f8f00594bc49440