### PR TITLE
Add Pydantic and Marshmallow tests

### DIFF
--- a/datason/__init__.py
+++ b/datason/__init__.py
@@ -127,8 +127,12 @@ try:
 except ImportError:
     _pickle_bridge_available = False
 
+# Validation helpers (always available, dependencies imported lazily)
 # Always import datetime_utils module for tests
-from . import datetime_utils  # noqa: F401
+from . import (
+    datetime_utils,  # noqa: F401
+    validation,  # noqa: F401
+)
 
 # Cache management functions
 from .cache_manager import (
@@ -139,6 +143,7 @@ from .cache_manager import (
     request_scope,  # noqa: F401
     reset_cache_metrics,  # noqa: F401
 )
+from .validation import serialize_marshmallow, serialize_pydantic  # noqa: F401
 
 
 def _get_version() -> str:
@@ -310,6 +315,9 @@ if _pickle_bridge_available:
             "get_ml_safe_classes",
         ]
     )
+
+# Always expose validation helpers
+__all__.extend(["serialize_pydantic", "serialize_marshmallow"])
 
 
 # Convenience functions for quick access

--- a/datason/core.py
+++ b/datason/core.py
@@ -897,6 +897,26 @@ def _serialize_full_path(
             # Fallback: Return enum value (legacy behavior when no config)
             return obj.value
 
+    # Handle Pydantic BaseModel objects
+    try:
+        from .validation import BaseModel  # type: ignore
+    except Exception:
+        BaseModel = None
+    if BaseModel is not None and isinstance(obj, BaseModel):
+        from .validation import serialize_pydantic
+
+        return serialize_pydantic(obj)
+
+    # Handle Marshmallow Schema objects
+    try:
+        from .validation import Schema  # type: ignore
+    except Exception:
+        Schema = None
+    if Schema is not None and isinstance(obj, Schema):
+        from .validation import serialize_marshmallow
+
+        return serialize_marshmallow(obj)
+
     # Handle objects with __dict__ (custom classes)
     if hasattr(obj, "__dict__"):
         # SECURITY: Early detection of problematic objects that can cause deep recursion

--- a/datason/validation.py
+++ b/datason/validation.py
@@ -1,0 +1,75 @@
+# Optional integration helpers for Pydantic and Marshmallow
+from typing import Any, Dict
+
+from .core import serialize
+
+_LAZY_IMPORTS = {
+    "BaseModel": None,
+    "Schema": None,
+}
+
+
+def _lazy_import_pydantic_base_model():
+    """Lazily import pydantic.BaseModel."""
+    if _LAZY_IMPORTS["BaseModel"] is None:
+        try:
+            from pydantic import BaseModel
+
+            _LAZY_IMPORTS["BaseModel"] = BaseModel
+        except Exception:
+            _LAZY_IMPORTS["BaseModel"] = False
+    return _LAZY_IMPORTS["BaseModel"] if _LAZY_IMPORTS["BaseModel"] is not False else None
+
+
+def _lazy_import_marshmallow_schema():
+    """Lazily import marshmallow.Schema."""
+    if _LAZY_IMPORTS["Schema"] is None:
+        try:
+            from marshmallow import Schema
+
+            _LAZY_IMPORTS["Schema"] = Schema
+        except Exception:
+            _LAZY_IMPORTS["Schema"] = False
+    return _LAZY_IMPORTS["Schema"] if _LAZY_IMPORTS["Schema"] is not False else None
+
+
+def serialize_pydantic(obj: Any) -> Any:
+    """Serialize a Pydantic model using datason."""
+    BaseModel = _lazy_import_pydantic_base_model()
+    if BaseModel is None:
+        raise ImportError("Pydantic is required for serialize_pydantic")
+    if isinstance(obj, BaseModel):
+        try:
+            data = obj.model_dump()  # Pydantic v2
+        except AttributeError:
+            try:
+                data = obj.dict()  # Pydantic v1
+            except Exception:
+                data = obj.__dict__
+        return serialize(data)
+    return serialize(obj)
+
+
+def serialize_marshmallow(obj: Any) -> Any:
+    """Serialize a Marshmallow schema object or validated data."""
+    Schema = _lazy_import_marshmallow_schema()
+    if Schema is None:
+        raise ImportError("Marshmallow is required for serialize_marshmallow")
+    if isinstance(obj, Schema):
+        try:
+            fields: Dict[str, Any] = {name: field.__class__.__name__ for name, field in obj.fields.items()}
+            return serialize(fields)
+        except Exception:
+            return serialize(obj.__dict__)
+    return serialize(obj)
+
+
+# Attribute access for tests
+
+
+def __getattr__(name: str) -> Any:
+    if name == "BaseModel":
+        return _lazy_import_pydantic_base_model()
+    if name == "Schema":
+        return _lazy_import_marshmallow_schema()
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/docs/features/pydantic-marshmallow-integration.md
+++ b/docs/features/pydantic-marshmallow-integration.md
@@ -1,0 +1,64 @@
+# Pydantic & Marshmallow Integration
+
+This document outlines how to integrate Datason with popular schema validation libraries **Pydantic** and **Marshmallow**. The goal is to keep validation and schema generation in their respective libraries while leveraging Datason for serialization and deserialization.
+
+## Background
+
+Many users validate input data with Pydantic or Marshmallow before working with ML/AI workflows. They want an easy way to serialize these validated objects using Datason without losing type fidelity.
+
+## Key Points
+
+- **Validation** remains the responsibility of Pydantic or Marshmallow.
+- **Serialization** is handled by Datason.
+- Integration helpers are optional and incur no new default dependencies.
+
+## Serializing Pydantic Models
+
+```python
+from pydantic import BaseModel
+import datason
+
+class MyModel(BaseModel):
+    a: int
+    b: str
+
+model = MyModel(a=1, b="foo")
+json_data = datason.serialize(model)  # Or datason.serialize_pydantic(model)
+```
+
+Datason automatically extracts fields from `BaseModel` instances, including nested models. Type information is preserved so the data can be deserialized back to Python primitives or dictionaries.
+
+## Serializing Marshmallow Objects
+
+```python
+from marshmallow import Schema, fields
+import datason
+
+class UserSchema(Schema):
+    id = fields.Int()
+    name = fields.Str()
+
+schema = UserSchema()
+user = schema.load({"id": 1, "name": "Alice"})
+json_data = datason.serialize(user)  # Or datason.serialize_marshmallow(user)
+```
+
+The helpers work with the results of `.load()` or `.dump()`, enabling seamless round-tripping through Datason without rewriting validation logic.
+
+## Optional Dependencies
+
+Datason’s core package does not require Pydantic or Marshmallow. If you use these helpers without installing the corresponding library, Datason raises a helpful `ImportError` explaining the missing dependency.
+
+## Documentation & Examples
+
+- [Using Datason with Pydantic](pydantic-marshmallow-integration.md)
+- [Using Datason with Marshmallow](pydantic-marshmallow-integration.md)
+
+Include real-world examples in the docs (e.g., FastAPI with Pydantic, Flask with Marshmallow) to demonstrate how Datason plugs into existing validation flows.
+
+## Limitations
+
+- Datason does not perform schema validation.
+- Custom Pydantic or Marshmallow fields may require user-defined type handlers for perfect fidelity.
+
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,6 +78,7 @@ assert type(restored['array']) == np.ndarray
     **Integration Guides**
 
     - [🤖 AI Integration Guide](ai-guide/overview.md) - How to integrate datason in AI systems
+    - [📦 Pydantic & Marshmallow Integration](features/pydantic-marshmallow-integration.md) - Serialize validated objects
     - [📝 API Reference](api/index.md) - Complete API documentation with examples
     - [🔧 Configuration Presets](features/configuration/index.md) - Pre-built configs for common AI use cases
 

--- a/tests/coverage/test_validation_helpers_coverage.py
+++ b/tests/coverage/test_validation_helpers_coverage.py
@@ -6,12 +6,17 @@ import datason
 
 def test_core_handles_missing_validation_imports(monkeypatch):
     """serialize should work even if validation imports fail."""
+
     def raise_import_error(name):
         raise ImportError("no validation")
 
     monkeypatch.setattr(datason.validation, "__getattr__", raise_import_error, raising=False)
-    monkeypatch.setattr(datason.validation, "serialize_pydantic", lambda obj: (_ for _ in ()).throw(AssertionError()), raising=False)
-    monkeypatch.setattr(datason.validation, "serialize_marshmallow", lambda obj: (_ for _ in ()).throw(AssertionError()), raising=False)
+    monkeypatch.setattr(
+        datason.validation, "serialize_pydantic", lambda obj: (_ for _ in ()).throw(AssertionError()), raising=False
+    )
+    monkeypatch.setattr(
+        datason.validation, "serialize_marshmallow", lambda obj: (_ for _ in ()).throw(AssertionError()), raising=False
+    )
 
     result = datason.serialize({"a": 1})
     assert result == {"a": 1}
@@ -19,6 +24,7 @@ def test_core_handles_missing_validation_imports(monkeypatch):
 
 def test_core_serializes_schema_instance(monkeypatch):
     """serialize should detect marshmallow Schema instances."""
+
     class DummyField:
         pass
 
@@ -37,6 +43,7 @@ def test_core_serializes_schema_instance(monkeypatch):
 
 def test_serialize_marshmallow_fields_exception(monkeypatch):
     """serialize_marshmallow should fall back to __dict__ on error."""
+
     class DummySchema:
         pass
 
@@ -101,6 +108,7 @@ def test_lazy_import_marshmallow_failure(monkeypatch):
 
 def test_serialize_pydantic_fallbacks(monkeypatch):
     """serialize_pydantic should fall back to dict and __dict__."""
+
     class Base:
         pass
 

--- a/tests/coverage/test_validation_helpers_coverage.py
+++ b/tests/coverage/test_validation_helpers_coverage.py
@@ -1,0 +1,122 @@
+import builtins
+import sys
+
+import datason
+
+
+def test_core_handles_missing_validation_imports(monkeypatch):
+    """serialize should work even if validation imports fail."""
+    def raise_import_error(name):
+        raise ImportError("no validation")
+
+    monkeypatch.setattr(datason.validation, "__getattr__", raise_import_error, raising=False)
+    monkeypatch.setattr(datason.validation, "serialize_pydantic", lambda obj: (_ for _ in ()).throw(AssertionError()), raising=False)
+    monkeypatch.setattr(datason.validation, "serialize_marshmallow", lambda obj: (_ for _ in ()).throw(AssertionError()), raising=False)
+
+    result = datason.serialize({"a": 1})
+    assert result == {"a": 1}
+
+
+def test_core_serializes_schema_instance(monkeypatch):
+    """serialize should detect marshmallow Schema instances."""
+    class DummyField:
+        pass
+
+    class DummySchema:
+        def __init__(self):
+            self.fields = {"x": DummyField(), "y": DummyField()}
+
+    datason.validation._LAZY_IMPORTS["Schema"] = DummySchema
+    # ensure __getattr__ returns our dummy class
+    monkeypatch.setattr(datason.validation, "_lazy_import_marshmallow_schema", lambda: DummySchema)
+
+    obj = DummySchema()
+    result = datason.serialize(obj)
+    assert result == {"x": "DummyField", "y": "DummyField"}
+
+
+def test_serialize_marshmallow_fields_exception(monkeypatch):
+    """serialize_marshmallow should fall back to __dict__ on error."""
+    class DummySchema:
+        pass
+
+    class BadSchema(DummySchema):
+        def __init__(self):
+            self.value = 123
+
+        @property
+        def fields(self):
+            raise RuntimeError("boom")
+
+    datason.validation._LAZY_IMPORTS["Schema"] = DummySchema
+    monkeypatch.setattr(datason.validation, "_lazy_import_marshmallow_schema", lambda: DummySchema)
+
+    obj = BadSchema()
+    result = datason.validation.serialize_marshmallow(obj)
+    assert result == {"value": 123}
+
+
+def test_lazy_import_pydantic_failure(monkeypatch):
+    """_lazy_import_pydantic_base_model returns None when import fails."""
+    datason.validation._LAZY_IMPORTS["BaseModel"] = None
+
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("pydantic"):
+            raise ImportError("no pydantic")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    if "pydantic" in sys.modules:
+        monkeypatch.delitem(sys.modules, "pydantic", raising=False)
+
+    result = datason.validation._lazy_import_pydantic_base_model()
+    assert result is None
+    assert datason.validation._LAZY_IMPORTS["BaseModel"] is False
+
+    monkeypatch.setattr(builtins, "__import__", original_import)
+
+
+def test_lazy_import_marshmallow_failure(monkeypatch):
+    """_lazy_import_marshmallow_schema returns None when import fails."""
+    datason.validation._LAZY_IMPORTS["Schema"] = None
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("marshmallow"):
+            raise ImportError("no mm")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    if "marshmallow" in sys.modules:
+        monkeypatch.delitem(sys.modules, "marshmallow", raising=False)
+
+    result = datason.validation._lazy_import_marshmallow_schema()
+    assert result is None
+    assert datason.validation._LAZY_IMPORTS["Schema"] is False
+
+    monkeypatch.setattr(builtins, "__import__", original_import)
+
+
+def test_serialize_pydantic_fallbacks(monkeypatch):
+    """serialize_pydantic should fall back to dict and __dict__."""
+    class Base:
+        pass
+
+    class ModelDict(Base):
+        def __init__(self):
+            self.a = 1
+
+        def dict(self):
+            return {"a": self.a}
+
+    class ModelNoMethods(Base):
+        def __init__(self):
+            self.b = 2
+
+    datason.validation._LAZY_IMPORTS["BaseModel"] = Base
+    monkeypatch.setattr(datason.validation, "_lazy_import_pydantic_base_model", lambda: Base)
+
+    assert datason.validation.serialize_pydantic(ModelDict()) == {"a": 1}
+    assert datason.validation.serialize_pydantic(ModelNoMethods()) == {"b": 2}

--- a/tests/features/test_validation_integration.py
+++ b/tests/features/test_validation_integration.py
@@ -1,0 +1,92 @@
+import pytest
+
+import datason
+
+
+@pytest.mark.features
+def test_serialize_pydantic_model() -> None:
+    BaseModel = pytest.importorskip("pydantic").BaseModel
+
+    class MyModel(BaseModel):
+        a: int
+        b: str
+
+    model = MyModel(a=1, b="foo")
+    result = datason.serialize(model)
+    assert result == {"a": 1, "b": "foo"}
+
+    result2 = datason.serialize_pydantic(model)
+    assert result2 == result
+
+
+@pytest.mark.features
+def test_serialize_marshmallow_object() -> None:
+    marshmallow = pytest.importorskip("marshmallow")
+
+    class UserSchema(marshmallow.Schema):
+        id = marshmallow.fields.Int()
+        name = marshmallow.fields.Str()
+
+    schema = UserSchema()
+    user = schema.load({"id": 1, "name": "Alice"})
+
+    result = datason.serialize(user)
+    assert result == {"id": 1, "name": "Alice"}
+
+    result2 = datason.serialize_marshmallow(user)
+    assert result2 == result
+
+
+@pytest.mark.features
+def test_pydantic_helper_import_error(monkeypatch) -> None:
+    """serialize_pydantic raises ImportError when pydantic is missing."""
+    monkeypatch.setitem(datason.validation._LAZY_IMPORTS, "BaseModel", False)
+
+    with pytest.raises(ImportError):
+        datason.validation.serialize_pydantic(object())
+
+
+def test_marshmallow_helper_import_error(monkeypatch) -> None:
+    """serialize_marshmallow raises ImportError when marshmallow is missing."""
+    monkeypatch.setitem(datason.validation._LAZY_IMPORTS, "Schema", False)
+
+    with pytest.raises(ImportError):
+        datason.validation.serialize_marshmallow(object())
+
+
+def test_lazy_import_pydantic_cached(monkeypatch) -> None:
+    """_lazy_import_pydantic_base_model caches the imported class."""
+    import sys
+    import types
+
+    dummy = type("DummyModel", (), {})
+    module = types.ModuleType("pydantic")
+    module.BaseModel = dummy
+    monkeypatch.setitem(sys.modules, "pydantic", module)
+    datason.validation._LAZY_IMPORTS["BaseModel"] = None
+
+    first = datason.validation._lazy_import_pydantic_base_model()
+    assert first is dummy
+
+    del sys.modules["pydantic"]
+    second = datason.validation._lazy_import_pydantic_base_model()
+    assert second is dummy  # cached
+
+
+def test_lazy_import_marshmallow_cached(monkeypatch) -> None:
+    """_lazy_import_marshmallow_schema caches the imported class."""
+    import sys
+    import types
+
+    dummy_schema = type("DummySchema", (), {})
+    module = types.ModuleType("marshmallow")
+    module.Schema = dummy_schema
+    monkeypatch.setitem(sys.modules, "marshmallow", module)
+    datason.validation._LAZY_IMPORTS["Schema"] = None
+
+    first = datason.validation._lazy_import_marshmallow_schema()
+    assert first is dummy_schema
+
+    del sys.modules["marshmallow"]
+    second = datason.validation._lazy_import_marshmallow_schema()
+    assert second is dummy_schema

--- a/tests/features/test_validation_integration.py
+++ b/tests/features/test_validation_integration.py
@@ -56,6 +56,7 @@ def test_marshmallow_helper_import_error(monkeypatch) -> None:
 
 def test_lazy_import_pydantic_cached(monkeypatch) -> None:
     """_lazy_import_pydantic_base_model caches the imported class."""
+
     import sys
     import types
 
@@ -75,6 +76,7 @@ def test_lazy_import_pydantic_cached(monkeypatch) -> None:
 
 def test_lazy_import_marshmallow_cached(monkeypatch) -> None:
     """_lazy_import_marshmallow_schema caches the imported class."""
+
     import sys
     import types
 

--- a/tests/integration/test_validation_full_round_trip.py
+++ b/tests/integration/test_validation_full_round_trip.py
@@ -1,0 +1,38 @@
+import pytest
+
+import datason
+
+
+def test_pydantic_round_trip() -> None:
+    BaseModel = pytest.importorskip("pydantic").BaseModel
+
+    class Model(BaseModel):
+        a: int
+        b: str
+
+    raw = {"a": 2, "b": "bar"}
+    model = Model(**raw)
+
+    serialized = datason.serialize(model)
+    deserialized = datason.deserialize(serialized)
+    new_model = Model(**deserialized)
+
+    assert new_model == model
+
+
+def test_marshmallow_round_trip() -> None:
+    marshmallow = pytest.importorskip("marshmallow")
+
+    class UserSchema(marshmallow.Schema):
+        id = marshmallow.fields.Int()
+        name = marshmallow.fields.Str()
+
+    schema = UserSchema()
+    raw = {"id": 3, "name": "Bob"}
+    user = schema.load(raw)
+
+    serialized = datason.serialize(user)
+    deserialized = datason.deserialize(serialized)
+    user2 = schema.load(deserialized)
+
+    assert user2 == user


### PR DESCRIPTION
## Summary
- extend validation tests for error conditions and lazy import helpers
- add round-trip integration tests for Pydantic and Marshmallow models
- fix ruff lint failures in imports

## Testing
- `pytest -q tests/features/test_validation_integration.py`
- `pytest -q tests/integration/test_validation_full_round_trip.py`


------
https://chatgpt.com/codex/tasks/task_e_6842f9de5a0483259f8f00594bc49440