### PR TITLE
Add Supabase docker env guide

### DIFF
--- a/docker/supabase/.env.example
+++ b/docker/supabase/.env.example
@@ -1,0 +1,5 @@
+# Example environment for running the local Supabase stack
+POSTGRES_PASSWORD=your-super-secret-postgres-password
+JWT_SECRET=your-super-secret-jwt-token-with-at-least-32-characters
+ANON_KEY=your-anon-key
+SERVICE_ROLE_KEY=your-service-role-key

--- a/docker/supabase/README.md
+++ b/docker/supabase/README.md
@@ -1,0 +1,19 @@
+# Supabase Local Development
+
+This directory contains the Docker configuration for running a local Supabase stack.
+
+## Setup
+
+1. Copy `.env.example` to `.env`.
+2. Edit `.env` and replace the placeholder values with your own secrets.
+   These secrets will also be used by GitHub Actions during CI.
+
+## Running Supabase
+
+Use `docker compose` with the `--env-file` option to start the services:
+
+```bash
+docker compose --env-file .env up
+```
+
+This command reads your customized environment file and launches the stack.


### PR DESCRIPTION
## Summary
- add example environment variables for Supabase Docker stack
- document how to copy `.env.example` to `.env`
- show how to run `docker compose` with `--env-file`
- note that CI uses the same `.env` file

## Testing
- `python -m pytest --override-ini addopts='' tests/core --maxfail=5 --tb=short`

------
https://chatgpt.com/codex/tasks/task_e_68434a4ef3e48325805a3f996c114ec4