### PR TITLE
Add ML model serving integration docs

### DIFF
--- a/docs/features/api-integration.md
+++ b/docs/features/api-integration.md
@@ -462,16 +462,16 @@ processed_users = datason.auto_deserialize(large_dataset, config=api_config)
 
 ## 📚 Related Documentation
 
-- [Configuration System](../configuration/) - Complete configuration reference
-- [Type Handling](../advanced-types/) - How datason handles different Python types
-- [Performance Guide](../performance/) - Optimization strategies
-- [Security Guide](../../SECURITY.md) - Security considerations for web APIs
+- [Configuration System](configuration/index.md) - Complete configuration reference
+- [Type Handling](advanced-types/index.md) - How datason handles different Python types
+- [Performance Guide](performance/index.md) - Optimization strategies
+- [Security Guide](../SECURITY.md) - Security considerations for web APIs
 
 ## 💡 Need Help?
 
 - **FastAPI specific questions**: Check our [FastAPI examples](../../examples/)
 - **Django integration**: See [Django integration patterns](../../examples/)
-- **Performance optimization**: Review [Performance Guide](../performance/)
-- **Custom configurations**: See [Configuration System](../configuration/)
+- **Performance optimization**: Review [Performance Guide](performance/index.md)
+- **Custom configurations**: See [Configuration System](configuration/index.md)
 
 The UUID/Pydantic compatibility issue is now solved! 🎉 Use `get_api_config()` for instant compatibility with modern Python web frameworks.

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -64,15 +64,19 @@ Comprehensive data analysis and transformation tools with consistent security pr
 - **Pandas/NumPy Integration**: Enhanced DataFrame and array processing with limits
 - **Configurable Security**: Environment-specific configurations for different trust levels
 
+
 ### [ML/AI Integration](ml-ai/index.md)
 Native support for machine learning and scientific computing objects.
 
 - **PyTorch**: Tensors, models, parameters
-- **TensorFlow**: Tensors, variables, SavedModel metadata  
+- **TensorFlow**: Tensors, variables, SavedModel metadata
 - **Scikit-learn**: Fitted models, pipelines, transformers
 - **NumPy**: Arrays, scalars, dtypes
 - **JAX**: Arrays and computation graphs
 - **PIL/Pillow**: Images with format preservation
+
+### [Model Serving Integration](model-serving/index.md)
+Guides for BentoML, Ray Serve, Streamlit, Gradio, MLflow, and Seldon/KServe.
 
 ### [Pandas Integration](pandas/index.md)
 Deep integration with the pandas ecosystem for data science workflows.

--- a/docs/features/model-serving/index.md
+++ b/docs/features/model-serving/index.md
@@ -1,0 +1,91 @@
+# Model Serving Integration
+
+Comprehensive guides for using **datason** with popular model serving and experiment tracking frameworks.
+
+These recipes show how to plug datason into each framework so your ML objects round-trip cleanly between training code, servers, and web APIs.
+
+## 🚀 BentoML
+
+```python
+import bentoml
+from bentoml.io import JSON
+import datason
+from datason.config import get_api_config
+
+svc = bentoml.Service("my_model_service")
+API_CONFIG = get_api_config()
+
+@svc.api(input=JSON(), output=JSON())
+def predict(parsed_json: dict) -> dict:
+    # Parse incoming JSON with datason
+    data = datason.auto_deserialize(parsed_json, config=API_CONFIG)
+    prediction = run_model(data)
+    # Serialize response for BentoML
+    return datason.serialize(prediction, config=API_CONFIG)
+```
+
+## ⚡ Ray Serve
+
+```python
+from ray import serve
+import datason
+from datason.config import get_api_config
+
+API_CONFIG = get_api_config()
+
+@serve.deployment
+class ModelDeployment:
+    async def __call__(self, request):
+        payload = await request.json()
+        data = datason.auto_deserialize(payload, config=API_CONFIG)
+        result = run_model(data)
+        return datason.serialize(result, config=API_CONFIG)
+```
+
+## 🎛️ Streamlit / Gradio
+
+```python
+import streamlit as st
+import datason
+from datason.config import get_api_config
+
+API_CONFIG = get_api_config()
+
+uploaded = st.file_uploader("Upload JSON")
+if uploaded:
+    raw = uploaded.read().decode()
+    data = datason.loads(raw, config=API_CONFIG)
+    prediction = run_model(data)
+    st.json(datason.dumps(prediction, config=API_CONFIG))
+```
+
+For Gradio, use the same pattern inside your `fn` callbacks.
+
+## 📦 MLflow Artifacts
+
+```python
+import mlflow
+import datason
+
+with mlflow.start_run():
+    result = train_model()
+    mlflow.log_dict(datason.serialize(result), "results.json")
+```
+
+## ☁️ Seldon Core / KServe
+
+```python
+from seldon_core.user_model import SeldonComponent
+import datason
+from datason.config import get_api_config
+
+API_CONFIG = get_api_config()
+
+class Model(SeldonComponent):
+    def predict(self, features, **kwargs):
+        data = datason.auto_deserialize(features, config=API_CONFIG)
+        output = run_model(data)
+        return datason.serialize(output, config=API_CONFIG)
+```
+
+These integrations ensure consistent JSON handling across your ML stack—BentoML or Ray Serve for serving, Streamlit/Gradio for demos, and MLflow for experiment tracking—all powered by datason's ML-friendly serialization.

--- a/examples/README.md
+++ b/examples/README.md
@@ -138,6 +138,46 @@ python examples/ai_ml_examples.py
 python examples/advanced_ml_examples.py
 ```
 
+### [`bentoml_integration_guide.py`](bentoml_integration_guide.py)
+
+**BentoML service using datason for request/response serialization.**
+
+```bash
+python examples/bentoml_integration_guide.py
+```
+
+### [`ray_serve_integration_guide.py`](ray_serve_integration_guide.py)
+
+**Ray Serve deployment with datason serialization.**
+
+```bash
+python examples/ray_serve_integration_guide.py
+```
+
+### [`streamlit_gradio_integration.py`](streamlit_gradio_integration.py)
+
+**UI demo for Streamlit and Gradio using datason.**
+
+```bash
+python examples/streamlit_gradio_integration.py
+```
+
+### [`mlflow_artifact_tracking.py`](mlflow_artifact_tracking.py)
+
+**Log datason artifacts to MLflow.**
+
+```bash
+python examples/mlflow_artifact_tracking.py
+```
+
+### [`seldon_kserve_integration.py`](seldon_kserve_integration.py)
+
+**Seldon Core / KServe model wrapper using datason.**
+
+```bash
+python examples/seldon_kserve_integration.py
+```
+
 **Features:**
 - Model checkpointing
 - Large tensor handling
@@ -281,8 +321,15 @@ python examples/django_integration_guide.py
 # Basic ML integration
 python examples/ai_ml_examples.py
 
-# Advanced ML workflows  
+# Advanced ML workflows
 python examples/advanced_ml_examples.py
+
+# Model serving examples
+python examples/bentoml_integration_guide.py
+python examples/ray_serve_integration_guide.py
+python examples/streamlit_gradio_integration.py
+python examples/mlflow_artifact_tracking.py
+python examples/seldon_kserve_integration.py
 ```
 
 ### 🔒 **Security & Production**
@@ -323,6 +370,11 @@ python examples/advanced_serialization_demo.py
 - [ ] Run `ai_ml_examples.py` for library support
 - [ ] Review `advanced_ml_examples.py` for workflows
 - [ ] Choose between `get_ml_config()` and `get_api_config()` based on needs
+- [ ] Try `bentoml_integration_guide.py` for BentoML services
+- [ ] Use `ray_serve_integration_guide.py` for Ray Serve deployments
+- [ ] Explore `streamlit_gradio_integration.py` for UI demos
+- [ ] Log experiments with `mlflow_artifact_tracking.py`
+- [ ] Wrap models using `seldon_kserve_integration.py`
 
 ---
 

--- a/examples/bentoml_integration_guide.py
+++ b/examples/bentoml_integration_guide.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""BentoML integration example using datason for JSON handling."""
+
+import bentoml
+from bentoml.io import JSON
+
+import datason
+from datason.config import get_api_config
+
+API_CONFIG = get_api_config()
+
+
+# Dummy model function
+def run_model(payload: dict) -> dict:
+    return {"echo": payload, "prediction": 1}
+
+
+svc = bentoml.Service("datason_bentoml_demo")
+
+
+@svc.api(input=JSON(), output=JSON())
+def predict(parsed_json: dict) -> dict:
+    data = datason.auto_deserialize(parsed_json, config=API_CONFIG)
+    result = run_model(data)
+    return datason.serialize(result, config=API_CONFIG)
+
+
+if __name__ == "__main__":
+    # `bentoml serve` will launch this service
+    print("Run with: bentoml serve bentoml_integration_guide:svc --reload")

--- a/examples/mlflow_artifact_tracking.py
+++ b/examples/mlflow_artifact_tracking.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""MLflow artifact logging with datason."""
+
+import mlflow
+
+import datason
+
+
+# Example training function
+def train_model():
+    return {"accuracy": 0.99, "params": {"lr": 0.001}}
+
+
+if __name__ == "__main__":
+    with mlflow.start_run():
+        results = train_model()
+        mlflow.log_dict(datason.serialize(results), "results.json")
+        print("Logged results to MLflow")

--- a/examples/ray_serve_integration_guide.py
+++ b/examples/ray_serve_integration_guide.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Ray Serve deployment using datason for request/response handling."""
+
+from ray import serve
+
+import datason
+from datason.config import get_api_config
+
+API_CONFIG = get_api_config()
+
+
+# Dummy model function
+def run_model(payload: dict) -> dict:
+    return {"echo": payload, "score": 0.5}
+
+
+@serve.deployment
+class ModelDeployment:
+    async def __call__(self, request):
+        payload = await request.json()
+        data = datason.auto_deserialize(payload, config=API_CONFIG)
+        result = run_model(data)
+        return datason.serialize(result, config=API_CONFIG)
+
+
+app = ModelDeployment.bind()
+
+if __name__ == "__main__":
+    print("Run with: serve run ray_serve_integration_guide:app")

--- a/examples/seldon_kserve_integration.py
+++ b/examples/seldon_kserve_integration.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Seldon Core / KServe example using datason."""
+
+from seldon_core.user_model import SeldonComponent
+
+import datason
+from datason.config import get_api_config
+
+API_CONFIG = get_api_config()
+
+
+# Dummy model function
+def run_model(payload: dict) -> dict:
+    return {"prediction": 123, "input": payload}
+
+
+class Model(SeldonComponent):
+    def predict(self, features, **kwargs):
+        data = datason.auto_deserialize(features, config=API_CONFIG)
+        output = run_model(data)
+        return datason.serialize(output, config=API_CONFIG)
+
+
+if __name__ == "__main__":
+    print("Use this class in your Seldon deployment")

--- a/examples/streamlit_gradio_integration.py
+++ b/examples/streamlit_gradio_integration.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Streamlit and Gradio example using datason for safe JSON."""
+
+import datason
+from datason.config import get_api_config
+
+API_CONFIG = get_api_config()
+
+
+# Dummy model function
+def run_model(payload: dict) -> dict:
+    return {"result": 42, "input": payload}
+
+
+# Streamlit demo
+try:
+    import streamlit as st
+except ImportError:
+    st = None
+
+if st is not None:
+    uploaded = st.file_uploader("Upload JSON")
+    if uploaded:
+        raw = uploaded.read().decode()
+        data = datason.loads(raw, config=API_CONFIG)
+        output = run_model(data)
+        st.json(datason.dumps(output, config=API_CONFIG))
+
+# Gradio demo
+try:
+    import gradio as gr
+except ImportError:
+    gr = None
+
+
+def gradio_predict(data: dict) -> dict:
+    parsed = datason.auto_deserialize(data, config=API_CONFIG)
+    result = run_model(parsed)
+    return datason.serialize(result, config=API_CONFIG)
+
+
+if gr is not None:
+    demo = gr.Interface(fn=gradio_predict, inputs="json", outputs="json")
+    if __name__ == "__main__":
+        demo.launch()
+elif __name__ == "__main__":
+    print("Install streamlit or gradio to run this demo")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,6 +141,7 @@ nav:
     - Chunked Processing: features/chunked-processing/index.md
     - Template Deserialization: features/template-deserialization/index.md
     - ML/AI Integration: features/ml-ai/index.md
+    - Model Serving Integration: features/model-serving/index.md
     - Pandas Integration: features/pandas/index.md
     - Pickle Bridge: features/pickle-bridge/index.md
     - Performance: features/performance/index.md


### PR DESCRIPTION
## Summary
- document model serving integrations
- mention new section in feature index and nav
- add example scripts for BentoML, Ray Serve, Streamlit, Gradio, MLflow and Seldon
- reference new examples in README

## Testing
- `pre-commit run --files mkdocs.yml docs/features/model-serving/index.md docs/features/index.md docs/features/api-integration.md examples/README.md examples/bentoml_integration_guide.py examples/ray_serve_integration_guide.py examples/streamlit_gradio_integration.py examples/mlflow_artifact_tracking.py examples/seldon_kserve_integration.py`
- `pytest -q` *(fails: 30 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6849e051f67883258b1c6010eb2cceea