### PR TITLE
Fix GitHub performance chart quoting

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -267,7 +267,7 @@ jobs:
                         # Extract datason standard performance only
                         if 'datason_standard' in test_data:
                             # Create shorter, more readable test names
-                            short_name = f'{category.replace("_", " ").title()}: {test_name.replace("_", " ").title()}'
+                            short_name = f\"{category.replace('_', ' ').title()}: {test_name.replace('_', ' ').title()}\"
                             data.append({
                                 'version': version,
                                 'timestamp': timestamp,


### PR DESCRIPTION
## Summary
- fix quoting bug for short_name generation in performance charts

## Testing
- `pytest -k 'nonexistenttest' -q` *(fails: ModuleNotFoundError: No module named 'datason')*

------
https://chatgpt.com/codex/tasks/task_e_684a208dd08c83259726dae25de409e0