### PR TITLE
Update docs for v0.10 and v0.11 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ datason transforms complex Python objects into JSON-serializable formats and bac
 - 📈 **Progressive Loading**: Choose your success rate - `load_basic` (60-70%), `load_smart` (80-90%), `load_perfect` (100%)
 - 🏗️ **Production Ready**: Enterprise-grade ML serving with monitoring, A/B testing, and security
 - 📝 **Integrity Verification**: Hash, sign, and verify objects for compliance workflows
+- 📂 **File Operations**: Save and load JSON/JSONL files with compression support
 
 ## 🤖 ML Framework Support
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -61,6 +61,7 @@ datason provides two complementary APIs designed for different use cases:
 ### Specialized Features
 - **[ML Integration](ml-integration.md)** - Machine learning library support
 - **[Data Privacy](data-privacy.md)** - Redaction engines and security features
+- **[Integrity Functions](integrity.md)** - Hashing and signature utilities
 - **[Type System](type-system.md)** - Advanced type handling and conversion
 - **[Utilities](utilities.md)** - Helper functions and data processing tools
 

--- a/docs/api/integrity.md
+++ b/docs/api/integrity.md
@@ -1,0 +1,116 @@
+# 🔐 Integrity Functions
+
+Datason includes a set of helpers for verifying data integrity and authenticity. These utilities provide deterministic hashing, optional redaction, and Ed25519 signatures.
+
+## 🎯 Function Overview
+
+| Function | Purpose | Best For |
+|----------|---------|---------|
+| `canonicalize()` | Deterministic JSON output | Stable hashing |
+| `hash_object()` | Hash Python objects | Audit trails |
+| `hash_json()` | Hash JSON structures | API responses |
+| `verify_object()` | Verify object integrity | Validation |
+| `verify_json()` | Verify JSON integrity | API testing |
+| `hash_and_redact()` | Redact then hash | Compliance |
+| `sign_object()` | Create digital signature | Authenticity |
+| `verify_signature()` | Validate signature | Document integrity |
+
+## 📦 Detailed Function Documentation
+
+### canonicalize()
+
+::: datason.integrity.canonicalize
+    options:
+      show_source: true
+      show_signature: true
+      show_signature_annotations: true
+
+### hash_object()
+
+::: datason.integrity.hash_object
+    options:
+      show_source: true
+      show_signature: true
+      show_signature_annotations: true
+
+### hash_json()
+
+::: datason.integrity.hash_json
+    options:
+      show_source: true
+      show_signature: true
+      show_signature_annotations: true
+
+### verify_object()
+
+::: datason.integrity.verify_object
+    options:
+      show_source: true
+      show_signature: true
+      show_signature_annotations: true
+
+### verify_json()
+
+::: datason.integrity.verify_json
+    options:
+      show_source: true
+      show_signature: true
+      show_signature_annotations: true
+
+### hash_and_redact()
+
+::: datason.integrity.hash_and_redact
+    options:
+      show_source: true
+      show_signature: true
+      show_signature_annotations: true
+
+### sign_object()
+
+::: datason.integrity.sign_object
+    options:
+      show_source: true
+      show_signature: true
+      show_signature_annotations: true
+
+### verify_signature()
+
+::: datason.integrity.verify_signature
+    options:
+      show_source: true
+      show_signature: true
+      show_signature_annotations: true
+
+**Basic Verification Example:**
+```python
+import datason
+from datason import integrity
+
+payload = {"id": 1, "value": 42}
+hash_val = integrity.hash_object(payload)
+assert integrity.verify_object(payload, hash_val)
+```
+
+**Signing Example:**
+```python
+from datason import integrity
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives import serialization
+
+private_key = Ed25519PrivateKey.generate()
+public_key = private_key.public_key()
+private_pem = private_key.private_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PrivateFormat.PKCS8,
+    encryption_algorithm=serialization.NoEncryption(),
+).decode("utf-8")
+public_pem = public_key.public_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PublicFormat.SubjectPublicKeyInfo,
+).decode("utf-8")
+
+document = {"msg": "hello"}
+
+signature = integrity.sign_object(document, private_pem)
+assert integrity.verify_signature(document, signature, public_pem)
+```

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -37,7 +37,7 @@ Comprehensive support for temporal data with timezone awareness.
 - **Pandas Integration**: `pd.Timestamp`, `pd.NaT`, `pd.DatetimeIndex`
 - **Timezone Support**: Aware and naive datetime handling
 
-### [File Operations](file-operations.md) 🆕 v0.9.1
+### [File Operations](file-operations.md) 🆕 v0.11.0
 Complete JSON/JSONL file I/O integrated as first-class citizens in the modern API.
 
 - **Dual Format Support**: Both JSON (.json) and JSONL (.jsonl) with auto-detection
@@ -73,6 +73,13 @@ Comprehensive data analysis and transformation tools with consistent security pr
 - **Pandas/NumPy Integration**: Enhanced DataFrame and array processing with limits
 - **Configurable Security**: Environment-specific configurations for different trust levels
 
+### [Data Integrity & Verification](../integrity.md) 🆕 v0.10.0
+Cryptographic hashing and signature utilities for tamper detection.
+
+- **Canonicalization**: Deterministic JSON for stable hashing
+- **Hash & Verify**: Object and JSON hashing with algorithm validation
+- **Digital Signatures**: Ed25519 sign/verify support
+- **Redaction Integration**: Optional PII removal before hashing
 
 ### [ML/AI Integration](ml-ai/index.md)
 Native support for machine learning and scientific computing objects.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -176,6 +176,7 @@ nav:
     - Specialized Features:
       - ML Integration: api/ml-integration.md
       - Data Privacy: api/data-privacy.md
+      - Integrity Functions: api/integrity.md
       - Type System: api/type-system.md
       - Utilities: api/utilities.md
     - Reference:


### PR DESCRIPTION
## Summary
- document new file operations feature in README
- update features index with file operations & data integrity
- add integrity functions to API reference
- link the new page in mkdocs nav

## Testing
- `pre-commit run -a`
- `pytest` *(fails: 38 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68502fc572588325a67a0820596e404c