### PR TITLE
Improve json API compatibility and preserve core type fidelity

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ with datason.config(**api_config().__dict__):
 | `max_size` | `int` | `100_000` | Max dict/list size (security) |
 | `fallback_to_string` | `bool` | `False` | `str()` unknown types instead of raising |
 | `strict` | `bool` | `True` | Raise on unrecognized type metadata |
+| `allow_plugin_deserialization` | `bool` | `True` | Allow plugin code to run during `loads`/`load` |
 | `redact_fields` | `tuple[str, ...]` | `()` | Field names to redact |
 | `redact_patterns` | `tuple[str, ...]` | `()` | Regex patterns to redact from strings |
 
@@ -203,6 +204,16 @@ is_valid, payload = verify_integrity(wrapped, key="secret")
 - **Circular reference detection** (prevents infinite loops)
 
 All limits raise `SecurityError` and are configurable.
+
+### Untrusted Input Recommendation
+
+If you load JSON from untrusted sources, disable plugin deserialization to avoid executing plugin code paths:
+
+```python
+safe = datason.loads(payload, allow_plugin_deserialization=False)
+```
+
+This still supports built-in collection hints (`tuple`, `set`, `frozenset`) but blocks plugin-based reconstruction.
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ assert isinstance(restored["weights"], torch.Tensor)
 ```python
 import datason
 
-datason.dumps(obj, **config)    # Serialize to JSON string
-datason.loads(s, **config)      # Deserialize from JSON string
-datason.dump(obj, fp, **config) # Write to file
-datason.load(fp, **config)      # Read from file
-datason.config(**config)        # Context manager for temp config
+datason.dumps(obj, **config)  # Serialize to JSON string
+datason.loads(s, **config)  # Deserialize from JSON string
+datason.dump(obj, fp, **config)  # Write to file
+datason.load(fp, **config)  # Read from file
+datason.config(**config)  # Context manager for temp config
 ```
 
 That's the entire public API.
@@ -148,10 +148,10 @@ with datason.config(sort_keys=True, nan_handling=NanHandling.STRING):
 from datason import ml_config, api_config, strict_config, performance_config
 
 with datason.config(**ml_config().__dict__):
-    datason.dumps(model_output)   # UNIX_MS dates, fallback to string
+    datason.dumps(model_output)  # UNIX_MS dates, fallback to string
 
 with datason.config(**api_config().__dict__):
-    datason.dumps(response)       # ISO dates, sorted keys, no type hints
+    datason.dumps(response)  # ISO dates, sorted keys, no type hints
 ```
 
 ### Config Options
@@ -233,6 +233,7 @@ from datason._protocols import TypePlugin, SerializeContext, DeserializeContext
 from datason._registry import default_registry
 from datason._types import TYPE_METADATA_KEY, VALUE_METADATA_KEY
 
+
 class MoneyPlugin:
     name = "money"
     priority = 400  # 400+ for user plugins
@@ -249,6 +250,7 @@ class MoneyPlugin:
     def deserialize(self, data, ctx):
         v = data[VALUE_METADATA_KEY]
         return Money(Decimal(v["amount"]), v["currency"])
+
 
 default_registry.register(MoneyPlugin())
 ```

--- a/datason/_config.py
+++ b/datason/_config.py
@@ -73,6 +73,9 @@ class SerializationConfig:
     fallback_to_string: bool = False
     strict: bool = True
 
+    # Deserialization safety
+    allow_plugin_deserialization: bool = True
+
     # Redaction (optional, for security module)
     redact_fields: tuple[str, ...] = field(default_factory=tuple)
     redact_patterns: tuple[str, ...] = field(default_factory=tuple)

--- a/datason/_core.py
+++ b/datason/_core.py
@@ -21,19 +21,17 @@ from .security.redaction import redact_value, should_redact_field
 
 _REDACTED = "[REDACTED]"
 _CONFIG_FIELDS = frozenset(SerializationConfig.__dataclass_fields__.keys())
-_JSON_DUMPS_KWARGS = frozenset(
-    {
-        "skipkeys",
-        "ensure_ascii",
-        "check_circular",
-        "allow_nan",
-        "cls",
-        "indent",
-        "separators",
-        "default",
-        "sort_keys",
-    }
-)
+_JSON_DUMPS_KWARGS = frozenset({
+    "skipkeys",
+    "ensure_ascii",
+    "check_circular",
+    "allow_nan",
+    "cls",
+    "indent",
+    "separators",
+    "default",
+    "sort_keys",
+})
 
 
 def _serialize_recursive(obj: Any, ctx: SerializeContext) -> Any:

--- a/datason/_core.py
+++ b/datason/_core.py
@@ -21,17 +21,19 @@ from .security.redaction import redact_value, should_redact_field
 
 _REDACTED = "[REDACTED]"
 _CONFIG_FIELDS = frozenset(SerializationConfig.__dataclass_fields__.keys())
-_JSON_DUMPS_KWARGS = frozenset({
-    "skipkeys",
-    "ensure_ascii",
-    "check_circular",
-    "allow_nan",
-    "cls",
-    "indent",
-    "separators",
-    "default",
-    "sort_keys",
-})
+_JSON_DUMPS_KWARGS = frozenset(
+    {
+        "skipkeys",
+        "ensure_ascii",
+        "check_circular",
+        "allow_nan",
+        "cls",
+        "indent",
+        "separators",
+        "default",
+        "sort_keys",
+    }
+)
 
 
 def _serialize_recursive(obj: Any, ctx: SerializeContext) -> Any:

--- a/datason/_deserialize.py
+++ b/datason/_deserialize.py
@@ -153,14 +153,16 @@ def load(fp: IOBase, **kwargs: Any) -> Any:
 
 
 _CONFIG_FIELDS = frozenset(SerializationConfig.__dataclass_fields__.keys())
-_JSON_LOADS_KWARGS = frozenset({
-    "cls",
-    "object_hook",
-    "parse_float",
-    "parse_int",
-    "parse_constant",
-    "object_pairs_hook",
-})
+_JSON_LOADS_KWARGS = frozenset(
+    {
+        "cls",
+        "object_hook",
+        "parse_float",
+        "parse_int",
+        "parse_constant",
+        "object_pairs_hook",
+    }
+)
 
 
 def _validate_load_kwargs(kwargs: dict[str, Any], *, func_name: str) -> None:

--- a/datason/_deserialize.py
+++ b/datason/_deserialize.py
@@ -53,9 +53,7 @@ def _deserialize_dict(data: dict[str, Any], ctx: DeserializeContext) -> Any:
         raw_value = data.get(VALUE_METADATA_KEY)
         if not isinstance(raw_value, list):
             if ctx.config.strict:
-                raise DeserializationError(
-                    f"Cannot deserialize {type_name}: expected list in {VALUE_METADATA_KEY}."
-                )
+                raise DeserializationError(f"Cannot deserialize {type_name}: expected list in {VALUE_METADATA_KEY}.")
             return data
         child = ctx.child()
         items = [_deserialize_recursive(item, child) for item in raw_value]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,6 +14,7 @@ with datason.config(sort_keys=True):
 
 # 3. Presets
 from datason import ml_config
+
 with datason.config(**ml_config().__dict__):
     datason.dumps(data)
 ```
@@ -67,10 +68,10 @@ Controls how `float('nan')` and `float('inf')` are serialized:
 ```python
 from datason import NanHandling
 
-datason.dumps({"v": float("nan")}, nan_handling=NanHandling.NULL)    # null
+datason.dumps({"v": float("nan")}, nan_handling=NanHandling.NULL)  # null
 datason.dumps({"v": float("nan")}, nan_handling=NanHandling.STRING)  # "NaN"
-datason.dumps({"v": float("nan")}, nan_handling=NanHandling.KEEP)    # NaN (invalid JSON!)
-datason.dumps({"v": float("nan")}, nan_handling=NanHandling.DROP)    # null
+datason.dumps({"v": float("nan")}, nan_handling=NanHandling.KEEP)  # NaN (invalid JSON!)
+datason.dumps({"v": float("nan")}, nan_handling=NanHandling.DROP)  # null
 ```
 
 ## DataFrameOrient

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,6 +32,7 @@ with datason.config(**ml_config().__dict__):
 | `max_string_length` | `int` | `1_000_000` | Max string length (security) |
 | `fallback_to_string` | `bool` | `False` | `str()` unknown types instead of raising |
 | `strict` | `bool` | `True` | Raise on unrecognized type metadata in `loads` |
+| `allow_plugin_deserialization` | `bool` | `True` | Allow plugin code to run during `loads`/`load` |
 | `redact_fields` | `tuple[str, ...]` | `()` | Field names to redact |
 | `redact_patterns` | `tuple[str, ...]` | `()` | Regex patterns to redact |
 
@@ -67,7 +68,7 @@ Controls how `float('nan')` and `float('inf')` are serialized:
 from datason import NanHandling
 
 datason.dumps({"v": float("nan")}, nan_handling=NanHandling.NULL)    # null
-datason.dumps({"v": float("nan")}, nan_handling=NanHandling.STRING)  # "nan"
+datason.dumps({"v": float("nan")}, nan_handling=NanHandling.STRING)  # "NaN"
 datason.dumps({"v": float("nan")}, nan_handling=NanHandling.KEEP)    # NaN (invalid JSON!)
 datason.dumps({"v": float("nan")}, nan_handling=NanHandling.DROP)    # null
 ```

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -25,6 +25,7 @@ class TestSerializationConfig:
         assert cfg.include_type_hints is True
         assert cfg.fallback_to_string is False
         assert cfg.strict is True
+        assert cfg.allow_plugin_deserialization is True
 
     def test_frozen(self):
         """Config is immutable."""
@@ -50,6 +51,7 @@ class TestPresets:
     def test_strict_config(self):
         cfg = strict_config()
         assert cfg.strict is True
+        assert cfg.allow_plugin_deserialization is True
         assert cfg.fallback_to_string is False
 
     def test_performance_config(self):

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -115,6 +115,7 @@ class TestJsonCompatibilityArgs:
         value = datason.loads("1.25", parse_float=str)
         assert value == "1.25"
 
+
 class TestNanHandling:
     """Test NaN and Infinity handling."""
 

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -55,12 +55,24 @@ class TestDumpsContainers:
         assert datason.dumps([1, 2, 3]) == "[1, 2, 3]"
 
     def test_tuple_becomes_list(self):
-        result = json.loads(datason.dumps((1, 2, 3)))
+        result = json.loads(datason.dumps((1, 2, 3), include_type_hints=False))
         assert result == [1, 2, 3]
 
     def test_set_becomes_sorted_list(self):
-        result = json.loads(datason.dumps({3, 1, 2}))
+        result = json.loads(datason.dumps({3, 1, 2}, include_type_hints=False))
         assert sorted(result) == [1, 2, 3]
+
+    def test_tuple_round_trip_with_type_hints(self):
+        value = (1, 2, 3)
+        assert datason.loads(datason.dumps(value)) == value
+
+    def test_set_round_trip_with_type_hints(self):
+        value = {1, 2, 3}
+        assert datason.loads(datason.dumps(value)) == value
+
+    def test_frozenset_round_trip_with_type_hints(self):
+        value = frozenset({1, 2, 3})
+        assert datason.loads(datason.dumps(value)) == value
 
     def test_mixed_nested(self, sample_data):
         result = json.loads(datason.dumps(sample_data))
@@ -88,6 +100,21 @@ class TestRoundTrip:
         assert datason.loads(datason.dumps(value)) == value
 
 
+class TestJsonCompatibilityArgs:
+    """Test json-compatible kwargs are accepted."""
+
+    def test_dumps_indent(self):
+        out = datason.dumps({"a": 1}, indent=2)
+        assert out == '{\n  "a": 1\n}'
+
+    def test_dumps_ensure_ascii(self):
+        out = datason.dumps({"emoji": "🙂"}, ensure_ascii=True)
+        assert r"\ud83d\ude42" in out
+
+    def test_loads_parse_float(self):
+        value = datason.loads("1.25", parse_float=str)
+        assert value == "1.25"
+
 class TestNanHandling:
     """Test NaN and Infinity handling."""
 
@@ -97,7 +124,7 @@ class TestNanHandling:
 
     def test_nan_to_string(self):
         result = json.loads(datason.dumps(float("nan"), nan_handling=NanHandling.STRING))
-        assert result == "nan"
+        assert result == "NaN"
 
     def test_inf_to_null_default(self):
         result = json.loads(datason.dumps(float("inf")))

--- a/tests/unit/test_plugin_datetime.py
+++ b/tests/unit/test_plugin_datetime.py
@@ -223,6 +223,13 @@ class TestRoundTrip:
         result = datason.loads(serialized)
         assert result == obj
 
+    def test_naive_datetime_unix_ms_roundtrip_preserves_naive(self) -> None:
+        obj = dt.datetime(2024, 1, 15, 10, 30, 0)
+        serialized = datason.dumps(obj, date_format=DateFormat.UNIX_MS)
+        result = datason.loads(serialized)
+        assert result == obj
+        assert result.tzinfo is None
+
     def test_datetime_in_dict(self) -> None:
         data = {"created": dt.datetime(2024, 1, 15, 10, 30), "name": "test"}
         serialized = datason.dumps(data)


### PR DESCRIPTION
### Motivation
- Close gaps in the advertised "drop-in" behavior for `json.dumps`/`json.loads` by accepting common stdlib arguments and validating unknown kwargs. 
- Preserve collection type fidelity (especially `tuple`, `set`, `frozenset`) when type hints are enabled so round-trips do not lose identity. 
- Normalize float special-value string output and fix timezone-naive datetime round-trips for UNIX/UNIX_MS modes to avoid surprising semantics. 

### Description
- Split `dumps`/`dump` kwargs into Datason config overrides and allowed `json.dumps` kwargs, passing through accepted JSON options like `indent`, `ensure_ascii`, `skipkeys`, `separators`, and `default`, while applying config defaults when not provided (`datason/_core.py`).
- Emit built-in Datason metadata for `tuple`, `set`, and `frozenset` when `include_type_hints=True` and restore those types on `loads`, while preserving legacy list output when hints are disabled (`datason/_core.py`, `datason/_deserialize.py`).
- Canonicalize `NanHandling.STRING` outputs to `"NaN"`, `"Infinity"`, and `"-Infinity"` instead of lowercased strings (`datason/_core.py`).
- Preserve timezone-naive datetime semantics for `DateFormat.UNIX`/`UNIX_MS` by emitting a small dict containing a `timestamp` and `naive` marker and restoring a naive `datetime` when appropriate (`datason/plugins/datetime.py`).
- Accept and forward common `json.loads`/`json.load` parsing kwargs (`parse_float`, `parse_int`, `object_hook`, etc.) and validate unknown kwargs with clear `TypeError` messages (`datason/_deserialize.py`).
- Added and updated unit tests to cover JSON-compat arguments, collection round-trips, NaN string casing, and naive UNIX_MS datetime behavior (`tests/unit/test_core.py`, `tests/unit/test_plugin_datetime.py`).

### Testing
- Ran the full test suite with `uv run pytest -q`, resulting in `272 passed, 15 skipped` and no failures. 
- Ran targeted test runs `uv run pytest tests/unit/test_core.py tests/unit/test_plugin_datetime.py tests/unit/test_deserialize.py -q` which passed successfully. 
- Ran linter checks with `uv run ruff check datason tests` which produced no issues. 
- New and updated unit tests exercise `dumps`/`dump` JSON kwargs handling, `loads` kwargs, collection type fidelity, NaN string normalization, and naive datetime UNIX/UNIX_MS round-trips and passed in CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987c37200a08325a9a19d8910281025)